### PR TITLE
fix(deps): Update stack definition member versions

### DIFF
--- a/stack_definition.json
+++ b/stack_definition.json
@@ -38,7 +38,7 @@
         }
       ],
       "name": "primary-da",
-      "version_locator": "7df1e4ca-d54c-4fd0-82ce-3d13247308cd.a8887a40-ff3f-4ee8-bcfe-bcfd55360074"
+      "version_locator": "7df1e4ca-d54c-4fd0-82ce-3d13247308cd.409c11db-87b8-458a-bf47-24930b087a3a"
     },
     {
       "inputs": [
@@ -64,7 +64,7 @@
         }
       ],
       "name": "secondary-da",
-      "version_locator": "7df1e4ca-d54c-4fd0-82ce-3d13247308cd.a8887a40-ff3f-4ee8-bcfe-bcfd55360074"
+      "version_locator": "7df1e4ca-d54c-4fd0-82ce-3d13247308cd.409c11db-87b8-458a-bf47-24930b087a3a"
     }
   ]
 }


### PR DESCRIPTION
```
Update stack definition member versions[subprocess - update_stack_definition.py] INFO: Updating primary-da
[subprocess - update_stack_definition.py] INFO: current version: v1.2.0
[subprocess - update_stack_definition.py] INFO: latest version: v1.3.6
[subprocess - update_stack_definition.py] INFO: latest version locator: 7df1e4ca-d54c-4fd0-82ce-3d13247308cd.409c11db-87b8-458a-bf47-24930b087a3a
[subprocess - update_stack_definition.py] INFO: Updating primary-da to version v1.3.6
[subprocess - update_stack_definition.py] 
[subprocess - update_stack_definition.py] INFO: Updating secondary-da
[subprocess - update_stack_definition.py] INFO: current version: v1.2.0
[subprocess - update_stack_definition.py] INFO: latest version: v1.3.6
[subprocess - update_stack_definition.py] INFO: latest version locator: 7df1e4ca-d54c-4fd0-82ce-3d13247308cd.409c11db-87b8-458a-bf47-24930b087a3a
[subprocess - update_stack_definition.py] INFO: Updating secondary-da to version v1.3.6
```